### PR TITLE
Update ovmf-descriptors

### DIFF
--- a/descriptors/50-ovmf-x86_64-sev.json
+++ b/descriptors/50-ovmf-x86_64-sev.json
@@ -1,5 +1,5 @@
 {
-    "description": "UEFI firmware for x86_64, with AMD SEV",
+    "description": "UEFI firmware for x86_64, with AMD SEV (Stateless)",
     "interface-types": [
         "uefi"
     ],
@@ -20,7 +20,6 @@
         }
     ],
     "features": [
-        "acpi-s4",
 	"amd-sev",
 	"amd-sev-es",
 	"amd-sev-snp",

--- a/descriptors/60-ovmf-x86_64-tdx.json
+++ b/descriptors/60-ovmf-x86_64-tdx.json
@@ -1,0 +1,31 @@
+{
+    "description": "UEFI firmware for x86_64, with Intel TDX (Stateless)",
+    "interface-types": [
+        "uefi"
+    ],
+    "mapping": {
+        "device": "flash",
+	    "mode": "stateless",
+        "executable": {
+            "filename": "@DATADIR@/ovmf-x86_64-tdx-secureboot.bin",
+            "format": "raw"
+        }
+    },
+    "targets": [
+        {
+            "architecture": "x86_64",
+            "machines": [
+                "pc-q35-*"
+            ]
+        }
+    ],
+    "features": [
+        "enrolled-keys",
+        "intel-tdx",
+        "secure-boot",
+        "verbose-dynamic"
+    ],
+    "tags": [
+
+    ]
+}


### PR DESCRIPTION
Based on the "one patch, one change" rule, I've split [PR#1](https://github.com/SUSE/ovmf-descriptors/pull/1) into two separate patches: one for the SEV change and one for the TDX change.

38e9920 Add 60-ovmf-x86_64-tdx.json descriptor for Intel TDX images
4fffa79 Remove the acpi-s4 features tag for AMD SEV-SNP stateless images
