### PR TITLE
Update ovmf-descriptors for AMD SEV-SNP and Intel TDX

### DIFF
--- a/descriptors/50-ovmf-x86_64-sev-snp.json
+++ b/descriptors/50-ovmf-x86_64-sev-snp.json
@@ -1,11 +1,11 @@
 {
-    "description": "UEFI firmware for x86_64, with Intel TDX",
+    "description": "UEFI firmware for x86_64, with AMD SEV-SNP",
     "interface-types": [
         "uefi"
     ],
     "mapping": {
         "device": "memory",
-        "filename": "@DATADIR@/ovmf-x86_64-tdx-secureboot.bin"
+        "filename": "@DATADIR@/ovmf-x86_64-sev.bin"
     },
     "targets": [
         {
@@ -16,9 +16,7 @@
         }
     ],
     "features": [
-        "enrolled-keys",
-        "intel-tdx",
-        "secure-boot",
+        "amd-sev-snp",
         "verbose-dynamic"
     ],
     "tags": [

--- a/descriptors/50-ovmf-x86_64-sev.json
+++ b/descriptors/50-ovmf-x86_64-sev.json
@@ -5,7 +5,7 @@
     ],
     "mapping": {
         "device": "flash",
-	"mode": "stateless",
+        "mode": "stateless",
         "executable": {
             "filename": "@DATADIR@/ovmf-x86_64-sev.bin",
             "format": "raw"
@@ -20,9 +20,8 @@
         }
     ],
     "features": [
-	"amd-sev",
-	"amd-sev-es",
-	"amd-sev-snp",
+        "amd-sev",
+        "amd-sev-es",
         "verbose-dynamic"
     ],
     "tags": [


### PR DESCRIPTION
Update ovmf-descriptors for AMD SEV-SNP and Intel TDX
- Add 50-ovmf-x86_64-sev-snp.json descriptor for AMD SEV-SNP image
- Removed "amd-sev-snp" feature tags from 50-ovmf-x86_64-sev.json
- Updated 60-ovmf-x86_64-tdx.json descriptor